### PR TITLE
docs: Update noticeNetworkFailure deprecation

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-network-failure.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-network-failure.mdx
@@ -22,7 +22,12 @@ Records network failures.
 
 ## Requirements
 
-Compatible with all agent versions.
+Compatible with agent versions 6.9.0 and below.
+
+<Callout variant="important">
+  As of New Relic [Android agent version 6.9.2](/docs/release-notes/mobile-release-notes/android-release-notes/android-692), the `noticeNetworkFailure` method is deprecated. The `noticeNetworkFailure` method will continue to work on versions 6.9.0 and below, but if your app contains `noticeNetworkFailure` methods, New Relic recommends you replace them with [noticeHttpTransaction](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-http-transaction/).
+</Callout>
+
 
 ## Description
 


### PR DESCRIPTION
Adding a warning and documenting `noticeNetworkFailure` deprecation